### PR TITLE
fixed minor grammar errors in training.py

### DIFF
--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -296,5 +296,5 @@ def prepare_index(blocker, pairs, matching) :
 
        
 
-OUT_OF_PREDICATES_WARNING = "Ran out of predicates: Dedupe tries to find blocking rules that will work well with your data. Sometimes it can't find great ones, and you'll get this warning. It means that there are some pairs of true records that you dedupe may never compare. If you are getting bad results, try increasing the ppc argument to the train method (if it less than 1.0)"
+OUT_OF_PREDICATES_WARNING = "Ran out of predicates: Dedupe tries to find blocking rules that will work well with your data. Sometimes it can't find great ones, and you'll get this warning. It means that there are some pairs of true records that dedupe may never compare. If you are getting bad results, try increasing the ppc argument to the train method (if it is less than 1.0)"
 


### PR DESCRIPTION
Very minor edit.
Improved clarity of the message "OUT_OF_PREDICATES_WARNING" by fixing some obvious grammar issues.